### PR TITLE
Clean-up legacy references to Boolector/btor

### DIFF
--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(PythonExtensions REQUIRED)
 find_package(Cython REQUIRED)
 
 include_directories(${PYTHON_INCLUDE_DIRS})
-include_directories(${CMAKE_CURRENT_LIST_DIR})               # btorapi.pxd
+include_directories(${CMAKE_CURRENT_LIST_DIR})               # bitwuzla_api.pxd
 include_directories(${CMAKE_CURRENT_LIST_DIR}/../c/)         # bitwuzla.h
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/api/python/mkenums.py
+++ b/src/api/python/mkenums.py
@@ -59,7 +59,7 @@ def extract_enums(header):
             # Get the next line
             line = next(line_iter)
 
-            # We expect this to be an opening curly, given Boolector's style
+            # We expect this to be an opening curly, given Bitwuzla's style
             if line != "{":
                 raise BitwuzlaEnumParseError(enum_name)
 

--- a/src/api/python/pybitwuzla.pyx
+++ b/src/api/python/pybitwuzla.pyx
@@ -534,7 +534,7 @@ cdef class Bitwuzla:
             Check satisfiability of asserted and assumed input formulas.
 
             Input formulas can either be asserted via
-            :func:`~pybitwuzla.Boolector.Assert` or
+            :func:`~pybitwuzla.Bitwuzla.assert_formula` or
             assumed via :func:`~pybitwuzla.Bitwuzla.assume_formula`.
 
             If this function is called multiple times it is required to
@@ -647,7 +647,7 @@ cdef class Bitwuzla:
 
             Unsat assumptions are those assumptions that force an
             input formula to become unsatisfiable.
-            Unsat assumptions handling in Boolector is analogous to
+            Unsat assumptions handling in Bitwuzla is analogous to
             unsatisfiable assumptions in MiniSAT.
 
             See :func:`~pybitwuzla.Bitwuzla.assume_formula`.

--- a/src/api/python/pybitwuzla_utils.h
+++ b/src/api/python/pybitwuzla_utils.h
@@ -22,7 +22,7 @@ extern "C" {
 /*!
    Set a Python termination callback.
 
-   :param btor:  Bitwuzla instance.
+   :param bzla:  Bitwuzla instance.
    :param fun:   The termination callback Python function.
    :param state: The Python argument(s) to the termination callback function.
 
@@ -35,7 +35,7 @@ void pybitwuzla_set_term(Bitwuzla* bitwuzla, PyObject* fun, PyObject* state);
   Delete a Bitwuzla instance (with possibly defined Python function
   callbacks) and free its resources.
 
-  :param btor: Bitwuzla instance.
+  :param bzla: Bitwuzla instance.
 
   .. seealso::
     bitwuzla_delete


### PR DESCRIPTION
This PR removes some legacy references to Boolector that were left in the Python API.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>