### PR TITLE
Add initial support for getting assignments of bit-vectors and floating point

### DIFF
--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(PythonExtensions REQUIRED)
 find_package(Cython REQUIRED)
 
 include_directories(${PYTHON_INCLUDE_DIRS})
-include_directories(${CMAKE_CURRENT_LIST_DIR})               # btorapi.pxd
+include_directories(${CMAKE_CURRENT_LIST_DIR})               # bitwuzla_api.pxd
 include_directories(${CMAKE_CURRENT_LIST_DIR}/../c/)         # bitwuzla.h
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/api/python/bitwuzla_api.pxd
+++ b/src/api/python/bitwuzla_api.pxd
@@ -419,6 +419,9 @@ cdef extern from "bitwuzla.h":
             const BitwuzlaTerm *term, const char *symbol) \
         except +raise_py_error
 
+    const char *bitwuzla_get_bv_value(Bitwuzla *bitwuzla, const BitwuzlaTerm *term) \
+      except +raise_py_error
+
 #    bool bitwuzla_term_is_equal_sort(const BitwuzlaTerm *term0,
 #                                     const BitwuzlaTerm *term1) \
 #        except +raise_py_error

--- a/src/api/python/bitwuzla_api.pxd
+++ b/src/api/python/bitwuzla_api.pxd
@@ -422,6 +422,16 @@ cdef extern from "bitwuzla.h":
     const char *bitwuzla_get_bv_value(Bitwuzla *bitwuzla, const BitwuzlaTerm *term) \
       except +raise_py_error
 
+    const char *bitwuzla_get_bv_value(Bitwuzla *bitwuzla, const BitwuzlaTerm *term) \
+      except +raise_py_error
+
+    void bitwuzla_get_fp_value(Bitwuzla *bitwuzla, \
+                          const BitwuzlaTerm *term, \
+                          const char **sign, \
+                          const char **exponent, \
+                          const char **significand) \
+      except +raise_py_error
+
 #    bool bitwuzla_term_is_equal_sort(const BitwuzlaTerm *term0,
 #                                     const BitwuzlaTerm *term1) \
 #        except +raise_py_error

--- a/src/api/python/mkenums.py
+++ b/src/api/python/mkenums.py
@@ -59,7 +59,7 @@ def extract_enums(header):
             # Get the next line
             line = next(line_iter)
 
-            # We expect this to be an opening curly, given Boolector's style
+            # We expect this to be an opening curly, given Bitwuzla's style
             if line != "{":
                 raise BitwuzlaEnumParseError(enum_name)
 

--- a/src/api/python/pybitwuzla.pyx
+++ b/src/api/python/pybitwuzla.pyx
@@ -534,7 +534,7 @@ cdef class Bitwuzla:
             Check satisfiability of asserted and assumed input formulas.
 
             Input formulas can either be asserted via
-            :func:`~pybitwuzla.Boolector.Assert` or
+            :func:`~pybitwuzla.Bitwuzla.assert_formula` or
             assumed via :func:`~pybitwuzla.Bitwuzla.assume_formula`.
 
             If this function is called multiple times it is required to
@@ -647,7 +647,7 @@ cdef class Bitwuzla:
 
             Unsat assumptions are those assumptions that force an
             input formula to become unsatisfiable.
-            Unsat assumptions handling in Boolector is analogous to
+            Unsat assumptions handling in Bitwuzla is analogous to
             unsatisfiable assumptions in MiniSAT.
 
             See :func:`~pybitwuzla.Bitwuzla.assume_formula`.

--- a/src/api/python/pybitwuzla.pyx
+++ b/src/api/python/pybitwuzla.pyx
@@ -349,6 +349,28 @@ cdef class BitwuzlaTerm:
     def is_indexed(self):
         return bitwuzla_api.bitwuzla_term_is_indexed(self.ptr())
 
+    property assignment:
+        """ The assignment of a Bitwuzla node.
+
+            May be queried only after a preceding call to
+            :func:`~pyboolector.Bitwuzla.Sat` returned
+            :data:`~pyboolector.Bitwuzla.SAT`.
+
+            If the queried node is a bit vector, its assignment is
+            represented as string.
+            Arrays, functions and floating point numbers are not currently
+            supported.
+        """
+        def __get__(self):
+            if self.is_bv():
+                c_str = \
+                    bitwuzla_api.bitwuzla_get_bv_value(self.bitwuzla._c_bitwuzla,
+                                                    self.ptr())
+                value = _to_str(c_str)
+                return value
+            else:
+              raise BitwuzlaException("Unable to get the assignment for a non-bit-vector")
+
 #
 #    void bitwuzla_term_dump(const BitwuzlaTerm *term,
 #                            const char *format,

--- a/src/api/python/pybitwuzla.pyx
+++ b/src/api/python/pybitwuzla.pyx
@@ -356,20 +356,37 @@ cdef class BitwuzlaTerm:
             :func:`~pyboolector.Bitwuzla.Sat` returned
             :data:`~pyboolector.Bitwuzla.SAT`.
 
-            If the queried node is a bit vector, its assignment is
-            represented as string.
-            Arrays, functions and floating point numbers are not currently
-            supported.
+            If the queried node is a bit vector and floating point, its
+            assignment is represented as string.
+
+            Arrays and functions are not currently supported.
         """
         def __get__(self):
+            cdef const char *sign = NULL
+            cdef const char *exponent = NULL
+            cdef const char *significand = NULL
+            cdef const char *c_str = NULL
+
             if self.is_bv():
                 c_str = \
                     bitwuzla_api.bitwuzla_get_bv_value(self.bitwuzla._c_bitwuzla,
                                                     self.ptr())
                 value = _to_str(c_str)
                 return value
+            if self.is_fp():
+                bitwuzla_api.bitwuzla_get_fp_value(self.bitwuzla._c_bitwuzla,
+                                                self.ptr(),
+                                                &sign,
+                                                &exponent,
+                                                &significand)
+                s_sign = _to_str(sign)
+                s_exponent = _to_str(exponent)
+                s_significand = _to_str(significand)
+                return (s_sign, s_exponent, s_significand)
             else:
-              raise BitwuzlaException("Unable to get the assignment for a non-bit-vector")
+              raise BitwuzlaException("Assignments are currently only supported "
+                                      "for bit-vectors and floats")
+
 
 #
 #    void bitwuzla_term_dump(const BitwuzlaTerm *term,

--- a/src/api/python/pybitwuzla_utils.h
+++ b/src/api/python/pybitwuzla_utils.h
@@ -22,7 +22,7 @@ extern "C" {
 /*!
    Set a Python termination callback.
 
-   :param btor:  Bitwuzla instance.
+   :param bzla:  Bitwuzla instance.
    :param fun:   The termination callback Python function.
    :param state: The Python argument(s) to the termination callback function.
 
@@ -35,7 +35,7 @@ void pybitwuzla_set_term(Bitwuzla* bitwuzla, PyObject* fun, PyObject* state);
   Delete a Bitwuzla instance (with possibly defined Python function
   callbacks) and free its resources.
 
-  :param btor: Bitwuzla instance.
+  :param bzla: Bitwuzla instance.
 
   .. seealso::
     bitwuzla_delete


### PR DESCRIPTION
This sits on top of https://github.com/bitwuzla/bitwuzla/pull/21.

There is no way that this is complete, but this is a "v0.0001" to getting assignments out of Bitwuzla via Python.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>