### PR TITLE
Mark SymFPU as a 'system' include path to remove warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,7 +147,7 @@ if(MiniSat_FOUND)
 endif()
 
 if(SymFPU_FOUND)
-  target_include_directories(bitwuzla PRIVATE ${SymFPU_INCLUDE_DIR})
+  target_include_directories(bitwuzla SYSTEM PRIVATE ${SymFPU_INCLUDE_DIR})
 endif()
 
 install(TARGETS bitwuzla


### PR DESCRIPTION
Changing SymFPU's include directory to be `SYSTEM` will remove this warning:

```
[85/92] Building CXX object src/CMakeFiles/bitwuzla.dir/bzlafp.cpp.o
In file included from /home/avj/clones/bitwuzla/main/src/bzlafp.cpp:35:
/home/avj/clones/bitwuzla/main/deps/install/include/symfpu/core/convert.h: In instantiation of ‘symfpu::significandRounderResult<t> symfpu::convertFloatToBV(const typename t::fpt&, const typename t::rm&, const symfpu::unpackedFloat<t>&, const typename t::bwt&, const typename t::bwt&) [with t = BzlaFPSymTraits; typename t::fpt = BzlaFPSortInfo; typename t::rm = BzlaFPSymRM; typename t::bwt = unsigned int]’:
/home/avj/clones/bitwuzla/main/deps/install/include/symfpu/core/convert.h:481:56:   required from ‘typename t::sbv symfpu::convertFloatToSBV(const typename t::fpt&, const typename t::rm&, const symfpu::unpackedFloat<t>&, const typename t::bwt&, const typename t::sbv&, const typename t::bwt&) [with t = BzlaFPSymTraits; typename t::sbv = BzlaFPSymBV<true>; typename t::fpt = BzlaFPSortInfo; typename t::rm = BzlaFPSymRM; typename t::bwt = unsigned int]’
/home/avj/clones/bitwuzla/main/src/bzlafp.cpp:2582:71:   required from here
/home/avj/clones/bitwuzla/main/deps/install/include/symfpu/core/convert.h:253:73: warning: unused parameter ‘format’ [-Wunused-parameter]
  253 |    significandRounderResult<t> convertFloatToBV (const typename t::fpt &format,
      |                                                  ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
```

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>