### PR TITLE
Update Kissat, add enable_verbosity to Kissat and incremental solving via Kissat Extras

### DIFF
--- a/contrib/setup-kissat-extras-git.sh
+++ b/contrib/setup-kissat-extras-git.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+###
+# Bitwuzla: Satisfiability Modulo Theories (SMT) solver.
+#
+# This file is part of Bitwuzla.
+#
+# Copyright (C) 2007-2022 by the authors listed in the AUTHORS file.
+#
+# See COPYING for more information on using this software.
+##
+
+set -e -o pipefail
+
+source "$(dirname "$0")/setup-utils.sh"
+
+KISSAT_DIR="${DEPS_DIR}/kissat"
+
+rm -rf "${KISSAT_DIR}"
+
+# Download and build Kissat Extras
+download_github jix/kissat_extras main "${KISSAT_DIR}"
+cd "${KISSAT_DIR}"
+
+./configure -fPIC ${EXTRA_FLAGS}
+make -j${NPROC}
+install_lib build/libkissat.a
+install_include src/kissat.h
+
+if grep -q 'dev' VERSION; then
+  echo
+  echo "This is a development snapshot of Kissat Extras and might not be ready for production use."
+  echo
+fi

--- a/contrib/setup-kissat.sh
+++ b/contrib/setup-kissat.sh
@@ -26,7 +26,7 @@ rm -rf "${KISSAT_DIR}"
 download_github arminbiere/kissat 02cd69626a53e93e09286b1978ccb5d6bec58b8e "${KISSAT_DIR}"
 cd "${KISSAT_DIR}"
 
-./configure -fPIC --quiet ${EXTRA_FLAGS}
+./configure -fPIC ${EXTRA_FLAGS}
 make -j${NPROC}
 install_lib build/libkissat.a
 install_include src/kissat.h

--- a/contrib/setup-kissat.sh
+++ b/contrib/setup-kissat.sh
@@ -18,10 +18,12 @@ KISSAT_DIR="${DEPS_DIR}/kissat"
 rm -rf "${KISSAT_DIR}"
 
 # Download and build Kissat
-curl -o kissat.tar.xz -L http://fmv.jku.at/kissat/kissat-sc2020-039805f2.tar.xz
-tar xf kissat.tar.xz
-rm kissat.tar.xz
-mv kissat-sc2020-039805f2 "${KISSAT_DIR}"
+
+# This commit is version 2.0.1 which behaves identically to version
+# sc2021-sweep but removes an unconditional runtime assertion ("coverage goal")
+# and avoids the "undefined reference to `kissat_signal_name'" error that
+# previously occured for some setups.
+download_github arminbiere/kissat 02cd69626a53e93e09286b1978ccb5d6bec58b8e "${KISSAT_DIR}"
 cd "${KISSAT_DIR}"
 
 ./configure -fPIC --quiet ${EXTRA_FLAGS}

--- a/src/sat/bzlakissat.c
+++ b/src/sat/bzlakissat.c
@@ -24,7 +24,11 @@ init(BzlaSATMgr *smgr)
 {
   kissat *slv;
 
+#ifdef KISSAT_EXTRAS
+  BZLA_MSG(smgr->bzla->msg, 1, "Kissat Extras Version %s", kissat_version());
+#else
   BZLA_MSG(smgr->bzla->msg, 1, "Kissat Version %s", kissat_version());
+#endif
 
   slv = kissat_init();
 
@@ -70,6 +74,22 @@ reset(BzlaSATMgr *smgr)
   smgr->solver = 0;
 }
 
+#ifdef KISSAT_EXTRAS
+
+static void
+assume(BzlaSATMgr *smgr, int32_t lit)
+{
+  kissat_assume(smgr->solver, lit);
+}
+
+static int32_t
+failed(BzlaSATMgr *smgr, int32_t lit)
+{
+  return kissat_failed(smgr->solver, lit);
+}
+
+#endif
+
 /*------------------------------------------------------------------------*/
 
 bool
@@ -98,6 +118,13 @@ bzla_sat_enable_kissat(BzlaSATMgr *smgr)
   smgr->api.set_output       = 0;
   smgr->api.set_prefix       = 0;
   smgr->api.stats            = 0;
+
+#ifdef KISSAT_EXTRAS
+  smgr->api.assume           = assume;
+  smgr->api.failed           = failed;
+
+  smgr->have_restore = true;
+#endif
   return true;
 }
 /*------------------------------------------------------------------------*/

--- a/src/sat/bzlakissat.c
+++ b/src/sat/bzlakissat.c
@@ -55,6 +55,15 @@ deref(BzlaSATMgr *smgr, int32_t lit)
 }
 
 static void
+enable_verbosity(BzlaSATMgr *smgr, int32_t level)
+{
+  if (level <= 1)
+    kissat_set_option(smgr->solver, "quiet", 1);
+  else if (level >= 2)
+    kissat_set_option(smgr->solver, "verbose", level - 2);
+}
+
+static void
 reset(BzlaSATMgr *smgr)
 {
   kissat_release(smgr->solver);
@@ -77,7 +86,7 @@ bzla_sat_enable_kissat(BzlaSATMgr *smgr)
   smgr->api.add              = add;
   smgr->api.assume           = 0;
   smgr->api.deref            = deref;
-  smgr->api.enable_verbosity = 0;
+  smgr->api.enable_verbosity = enable_verbosity;
   smgr->api.failed           = 0;
   smgr->api.fixed            = 0;
   smgr->api.inc_max_var      = 0;


### PR DESCRIPTION
I've written patches to Kissat that add full incremental solving support (["Kissat Extras"](https://github.com/jix/kissat_extras)). For testing I've been using bitwuzla and these are the corresponding changes I've made to bitwuzla to enable incremental solving via Kissat.

Currently these are three independent commits:

  * Update to the latest Kissat version. (Version from sc2021 with minor fixes, previous versions fail to link on my system.)
  * Add enable_verbosity for Kissat, behaving in the same way as it currently does for CaDiCaL.
  * Add a setup script for my patched Kissat version and support for incremental solving when my patched version is detected at compile time.

While the readme says that all pull requests should be squashed into a single commit, I have not yet done so, as the three commits are independent and you might want to apply only a subset. Let me know if I should squash them, open separate PRs for them or do something else.