### PR TITLE
Add increment/decrement refcount to public API

### DIFF
--- a/src/api/c/bitwuzla.c
+++ b/src/api/c/bitwuzla.c
@@ -4673,3 +4673,18 @@ bitwuzla_add_output(Bitwuzla *bitwuzla, const BitwuzlaTerm *term)
 
   BZLA_PUSH_STACK(bzla->outputs, bzla_node_copy(bzla, bzla_term));
 }
+
+void
+bitwuzla_increment_refcount(Bitwuzla *bitwuzla, const BitwuzlaTerm *term) {
+  Bzla *bzla          = BZLA_IMPORT_BITWUZLA(bitwuzla);
+  BzlaNode *bzla_term = BZLA_IMPORT_BITWUZLA_TERM(term);
+  bzla_node_copy(bzla, bzla_term); // increment refs
+  bzla_node_inc_ext_ref_counter(bzla, bzla_term); // increment ext_refs
+}
+void
+bitwuzla_decrement_refcount(Bitwuzla *bitwuzla, const BitwuzlaTerm *term) {
+  Bzla *bzla          = BZLA_IMPORT_BITWUZLA(bitwuzla);
+  BzlaNode *bzla_term = BZLA_IMPORT_BITWUZLA_TERM(term);
+  bzla_node_dec_ext_ref_counter(bzla, bzla_term);
+  bzla_node_release(bzla, bzla_term);
+}

--- a/src/api/c/bitwuzla.h
+++ b/src/api/c/bitwuzla.h
@@ -3956,6 +3956,8 @@ void bitwuzla_term_dump(const BitwuzlaTerm *term,
                         const char *format,
                         FILE *file);
 
+void bitwuzla_decrement_refcount(Bitwuzla *bitwuzla, const BitwuzlaTerm *term);
+void bitwuzla_increment_refcount(Bitwuzla *bitwuzla, const BitwuzlaTerm *term);
 /* -------------------------------------------------------------------------- */
 
 #if __cplusplus


### PR DESCRIPTION
Hi! I'm not sure if there's another way to do this, but basically the situation I have is:

I have some variables 'x' and 'y', which are really coming from some IR and have a unique id there. When I want to translate these to Bitwuzla, I will do something like:
```
  BitwuzlaTerm *x = bitwuzla_mk_const(bzla, sortbv8, "unique_id1234");
  BitwuzlaTerm *y = bitwuzla_mk_const(bzla, sortbv8, "unique_id5678");
```

However since I'm working with an IR, frequently a variable will appear in multiple expressions. Since it *seems to me* that in Bitwuzla multiple `bitwuzla_mk_const` terms with the same name are actually distinct variables, I want to just have essentially a cache so that I create these `bitwuzla_mk_const` terms only the first time a variable is seen and then all later occurrences just use the existing term.

The only issue is I sometimes want to use incremental solving (bitwuzla_assume), which will (after the next query) release all the 0 refcount terms, including (sometimes) variables I'd like to keep around in this cache. (I concede that this is only a problem if the term I want to cache appears *only* in a bitwuzla_assume, and most assumptions only reference existing const terms. Perhaps I just can't stand to hold on to refcount-managed pointers without incrementing the refcount :))

The most flexible solution seems to be just to allow users to manually manage the lifetime of a BitwuzlaTerm with an increment and decrement API. I didn't see a public API that did this already. 