### PR TITLE
configure: show defaults in usage

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -57,7 +57,9 @@ def main():
     if shutil.which('meson') is None:
         die('meson not found on system, please install via pip.')
 
-    ap = argparse.ArgumentParser()
+    ap = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
     ap.add_argument('buildtype', nargs='?',
                     choices=['release', 'debug', 'debugoptimized'])
     ap.add_argument('--build-dir', default='build', metavar='DIR',


### PR DESCRIPTION
The patch enables showing default values in usage:

```
$ ./configure.py --help

<snipped>

options:
  -h, --help            show this help message and exit
  --build-dir DIR       build directory (default: build)
  --prefix PREFIX       install prefix (default: None)
  --shared              shared library (default: False)
  --static              static library (default: False)
  --assertions          enable assertions (default: None)
  --no-assertions       disable assertions (default: True)
  --asan                enable address sanitizer (default: False)
  --ubsan               enable undefined behavior sanitizer (default: False)
  --coverage            enable code coverage (default: False)
  --win64               enable cross compilation for 64-bit Windows (default: False)
  --python              build python bindings (default: False)
  --testing             enable regression and unit testing (default: None)
  --no-testing          disable regression and unit testing (default: True)
  --unit-testing        enable unit testing (default: None)
  --no-unit-testing     disable unit testing (default: True)
  --docs                build documentation (default: False)
  --wipe                delete build directory if it already exists (default: False)
  --kissat              compile with Kissat (default: False)
```