### PR TITLE
configure: pass environment variables to Meson

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -33,7 +33,7 @@ def configure_build(builddir, opts):
     cmd.append(builddir)
     cmd.extend(opts)
     info(' '.join(cmd))
-    subprocess.run(cmd)
+    subprocess.run(cmd, env=os.environ)
     info(f'compile Bitwuzla with: cd {builddir} && meson compile')
 
 def _feat(val):


### PR DESCRIPTION
The patch allows pass environment variables to a Meson. This allows setting compiler and linker on configuration stage, see [1].

1. https://mesonbuild.com/Reference-tables.html#compiler-and-linker-selection-variables