### PR TITLE
src: fix compiler warnings

### DIFF
--- a/src/api/c/parser.cpp
+++ b/src/api/c/parser.cpp
@@ -56,7 +56,7 @@ bitwuzla_parser_new(BitwuzlaOptions* options,
                     uint8_t base,
                     const char* outfile_name)
 {
-  BitwuzlaParser* res;
+  BitwuzlaParser* res = NULL;
   BITWUZLA_TRY_CATCH_BEGIN;
   BITWUZLA_CHECK_NOT_NULL(options);
   BITWUZLA_CHECK_NOT_NULL(infile_name);
@@ -96,7 +96,7 @@ bitwuzla_parser_parse(BitwuzlaParser* parser, bool parse_only)
 Bitwuzla*
 bitwuzla_parser_get_bitwuzla(BitwuzlaParser* parser)
 {
-  Bitwuzla* res;
+  Bitwuzla* res = NULL;
   BITWUZLA_TRY_CATCH_BEGIN;
   BITWUZLA_CHECK_NOT_NULL(parser);
   if (!parser->d_bitwuzla)


### PR DESCRIPTION
Fix compiler warnings:

```
[109/192] Compiling C++ object src/libbitwuzla.a.p/api_c_parser.cpp.o
../src/api/c/parser.cpp: In function ‘BitwuzlaParser* bitwuzla_parser_new(BitwuzlaOptions*, const char*, FILE*, const char*, uint8_t, const char*)’:
../src/api/c/parser.cpp:69:10: warning: ‘res’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   69 |   return res;
      |          ^~~
../src/api/c/parser.cpp: In function ‘Bitwuzla* bitwuzla_parser_get_bitwuzla(BitwuzlaParser*)’:
../src/api/c/parser.cpp:108:10: warning: ‘res’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  108 |   return res;
      |          ^~~
[192/192] Linking target
```

Compiler: gcc 11.4.0 "c++ (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"