### PR TITLE
Added missing headers

### DIFF
--- a/src/lib/bitblast/aig/aig_cnf.cpp
+++ b/src/lib/bitblast/aig/aig_cnf.cpp
@@ -10,6 +10,7 @@
 
 #include "bitblast/aig/aig_cnf.h"
 
+#include <cstdlib>
 #include <functional>
 #include <unordered_set>
 #include <vector>

--- a/src/lib/bitblast/aig/aig_manager.cpp
+++ b/src/lib/bitblast/aig/aig_manager.cpp
@@ -10,6 +10,8 @@
 
 #include "bitblast/aig/aig_manager.h"
 
+#include <cstdlib>
+
 namespace bzla::bitblast {
 
 // AigNodeUniqueTable

--- a/src/main/options.cpp
+++ b/src/main/options.cpp
@@ -2,6 +2,7 @@
 
 #include <bitwuzla/cpp/bitwuzla.h>
 
+#include <algorithm>
 #include <cassert>
 #include <iomanip>
 #include <iostream>

--- a/src/parser/smt2/parser.cpp
+++ b/src/parser/smt2/parser.cpp
@@ -10,6 +10,7 @@
 
 #include "parser/smt2/parser.h"
 
+#include <algorithm>
 #include <iostream>
 
 namespace bzla {


### PR DESCRIPTION
A small fix that allowed bitwuzla to compile.

Prior to these changes I had an error: `error: ‘all_of’ is not a member of ‘std’`