### PR TITLE
Fix parsing on get-value with uninterpreted functions

### DIFF
--- a/src/parser/smt2/parser.cpp
+++ b/src/parser/smt2/parser.cpp
@@ -1226,6 +1226,7 @@ Parser::parse_term(bool look_ahead, Token la)
    *       non-simplified expression) */
   Token token;
   bitwuzla::Term res;
+  int depth = 0;
 
   do
   {
@@ -1242,9 +1243,14 @@ Parser::parse_term(bool look_ahead, Token la)
     {
       return false;
     }
+    if (token == Token::LPAR)
+    {
+      depth++;
+    }
 
     if (token == Token::RPAR)
     {
+      depth--;
       if (!close_term())
       {
         return false;
@@ -1252,7 +1258,7 @@ Parser::parse_term(bool look_ahead, Token la)
     }
     else
     {
-      if (!parse_open_term(token))
+      if (!parse_open_term(token, depth == 0))
       {
         return false;
       }
@@ -1301,7 +1307,7 @@ Parser::parse_term_list(std::vector<bitwuzla::Term>& terms,
 }
 
 bool
-Parser::parse_open_term(Token token)
+Parser::parse_open_term(Token token, bool top_level)
 {
   assert(token != Token::RPAR);
   d_expect_body = false;
@@ -1389,7 +1395,7 @@ Parser::parse_open_term(Token token)
     {
       push_item(token, d_lexer->coo());
     }
-    if (!parse_open_term_symbol())
+    if (!parse_open_term_symbol(top_level))
     {
       return false;
     }
@@ -1668,7 +1674,7 @@ Parser::parse_open_term_quant()
 }
 
 bool
-Parser::parse_open_term_symbol()
+Parser::parse_open_term_symbol(bool top_level)
 {
   assert(!d_work.empty());
 
@@ -1761,7 +1767,10 @@ Parser::parse_open_term_symbol()
       }
       else
       {
-        push_item(Token::FUN_APP, d_lexer->coo());
+        if (!top_level)
+        {
+          push_item(Token::FUN_APP, d_lexer->coo());
+        }
       }
       push_item(Token::TERM, node->d_term, d_lexer->coo());
     }

--- a/src/parser/smt2/parser.h
+++ b/src/parser/smt2/parser.h
@@ -315,7 +315,7 @@ class Parser : public bzla::parser::Parser
   /**
    * Helper for parse_term, parse currently open term.
    */
-  bool parse_open_term(Token token);
+  bool parse_open_term(Token token, bool top_level);
   /**
    * Helper for parse_open_term, parse currently open (as ...) term.
    * @return False on error.
@@ -335,7 +335,7 @@ class Parser : public bzla::parser::Parser
    * Helper for parse_open_term, parse currently open symbol term.
    * @return False on error.
    */
-  bool parse_open_term_symbol();
+  bool parse_open_term_symbol(bool top_level);
 
   /**
    * Parse sort.

--- a/test/regress/meson.build
+++ b/test/regress/meson.build
@@ -54,6 +54,7 @@ tests_smt2 = [
   ['get-value/fp_real.smt2'],
   ['get-value/fp_regr9.smt2'],
   ['parser/echo.smt2'],
+  ['parser/get_value_uf.smt2'],
   ['parser/issue59-1.smt2'],
   ['parser/issue59-2.smt2'],
   ['parser/issue66.smt2'],

--- a/test/regress/parser/get_value_uf.expect
+++ b/test/regress/parser/get_value_uf.expect
@@ -1,0 +1,2 @@
+sat
+((f (lambda ((@bzla.var_2 Bool)) false)))

--- a/test/regress/parser/get_value_uf.smt2
+++ b/test/regress/parser/get_value_uf.smt2
@@ -1,0 +1,6 @@
+(set-option :global-declaration true)
+(set-option :produce-models true)
+(declare-fun f (Bool) Bool)
+(check-sat)
+(get-value (f))
+(declare-fun a () Bool)


### PR DESCRIPTION
On the following smt file:

```text
(set-option :global-declaration true)
(set-option :produce-models true)
(declare-fun f (Bool) Bool)
(check-sat)
(get-value (f))
(declare-fun a () Bool)
```

bitwuzla will give the following error message under debug build:

```text
bitwuzla: ../src/parser/smt2/parser.cpp:410: bool bzla::parser::smt2::Parser::parse_command_declare_fun(bool): Assertion `nargs() == 1' failed.
Aborted (core dumped)
```

The root cause for the bug is that the parser will always push a `FUN_APP` item when a function symbol is encountered. As shown in the following code snippet.

https://github.com/bitwuzla/bitwuzla/blob/0e81e616af4d4421729884f01928b194c3536c76/src/parser/smt2/parser.cpp#L1763-L1766

However, the arguments to the `get-value` syntax might be a single function symbol without being applied. This will leave an extra `FUN_APP` symbol on the stack (if I understand the code correctly).

This pull request adds the bug-revealing example to the test suite and fixes the bug by tracking whether we are at the top-level (meaning that an unapplied function symbol might be encountered), and only push the `FUN_APP` value when we are not at the top-level.
