### PR TITLE
Add terminator support for parser

### DIFF
--- a/include/bitwuzla/cpp/parser.h
+++ b/include/bitwuzla/cpp/parser.h
@@ -151,6 +151,8 @@ class Parser
    */
   std::shared_ptr<bitwuzla::Bitwuzla> bitwuzla();
 
+  void configure_terminator(bitwuzla::Terminator* terminator);
+
  private:
   std::unique_ptr<bzla::parser::Parser> d_parser;
 };

--- a/src/api/cpp/parser.cpp
+++ b/src/api/cpp/parser.cpp
@@ -127,6 +127,12 @@ Parser::bitwuzla()
   return d_parser->bitwuzla();
 }
 
+void Parser::configure_terminator(bitwuzla::Terminator* terminator)
+{
+  assert(d_parser);
+  d_parser->configure_terminator(terminator);
+}
+
 Parser::~Parser() {}
 
 /* -------------------------------------------------------------------------- */

--- a/src/api/python/bitwuzla_api.pxd
+++ b/src/api/python/bitwuzla_api.pxd
@@ -313,5 +313,5 @@ cdef extern from "bitwuzla/cpp/parser.h" namespace "bitwuzla::parser":
         vector[Term] get_declared_funs() except +raise_error
         string error_msg() except +raise_error
         shared_ptr[Bitwuzla] bitwuzla() except +raise_error
-
+        void configure_terminator(Terminator* terminator) except +raise_error
 # -------------------------------------------------------------------------- #


### PR DESCRIPTION
This commit introduces the ability to configure a terminator callback for the parser, allowing early termination during parsing/solving.
