### PR TITLE
Include `stdint.h` for GCC 15

### DIFF
--- a/include/bitwuzla/cpp/bitwuzla.h
+++ b/include/bitwuzla/cpp/bitwuzla.h
@@ -14,6 +14,7 @@
 #include <bitwuzla/enums.h>
 #include <bitwuzla/option.h>
 
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <map>


### PR DESCRIPTION
Without this include, Bitwuzla doesn't compile with GCC 15.1.1. It's needed for the `uint8_t` type used in `bitwuzla.h`.