### PR TITLE
Support Kissat 4.0.3

### DIFF
--- a/subprojects/kissat.wrap
+++ b/subprojects/kissat.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = kissat-rel-4.0.1
+directory = kissat-rel-4.0.3
 
-source_url = https://github.com/arminbiere/kissat/archive/refs/tags/rel-4.0.1.tar.gz
-source_filename = kissat-rel-4.0.1.tar.gz
-source_hash = 4b41edf12ffa5f8e8b1986e5ad3e0bedb4d34b0ed3ecc7c13362bc7ba0aba66b
+source_url = https://github.com/arminbiere/kissat/archive/refs/tags/rel-4.0.3.tar.gz
+source_filename = kissat-rel-4.0.3.tar.gz
+source_hash = 53ad0c86a3854cdbf16e871599de4eaaaf33a039c1fd3460e43c89ae2a8a0971
 
 patch_directory = kissat
 

--- a/subprojects/packagefiles/kissat/meson.build
+++ b/subprojects/packagefiles/kissat/meson.build
@@ -1,6 +1,6 @@
 project('kissat',
   'c',
-  version: '4.0.1',
+  version: '4.0.3',
   license: 'mit',
   default_options: [
     'c_std=c99',
@@ -9,6 +9,7 @@ project('kissat',
     'b_ndebug=if-release',
     'warning_level=0',
     'optimization=3',
+    'b_lto = true',
   ]
 )
 

--- a/subprojects/packagefiles/kissat/src/meson.build
+++ b/subprojects/packagefiles/kissat/src/meson.build
@@ -85,7 +85,6 @@ sources = [
   'shrink.c',
   'smooth.c',
   'sort.c',
-  'stack.c',
   'statistics.c',
   'strengthen.c',
   'substitute.c',


### PR DESCRIPTION
Dear maintainers,

This PR is similar to #124; it updates the Kissat to the latest version. I guess that version 4.0.3 is the submitted version for this year's SAT competition, though this is not clarified in the release note. 

Because this version adds LTO support, I enabled the LTO compile option for Kissat. 