### PR TITLE
meson: don't require Git as a compile-time dependency

### DIFF
--- a/src/get_git_id.py
+++ b/src/get_git_id.py
@@ -22,9 +22,14 @@ if not os.path.isdir(args.path):
 
 git_id = ''
 
+cmd_found = True
 cmd = ['git', '-C', args.path, 'rev-parse', '--abbrev-ref', 'HEAD']
-proc = subprocess.run(cmd, capture_output=True, check=False)
-if proc.returncode == 0 and proc.stdout:
+try:
+    proc = subprocess.run(cmd, capture_output=True, check=False)
+except FileNotFoundError:
+    cmd_found = False # git not installed
+
+if cmd_found and proc.returncode == 0 and proc.stdout:
     git_id += proc.stdout.decode().strip()
     git_id += '@'
     cmd = ['git', '-C', args.path, 'rev-parse', '--short', 'HEAD']

--- a/src/meson.build
+++ b/src/meson.build
@@ -102,7 +102,7 @@ license_text += '\n\n  SymFPU\n  https://github.com/martin-cs/symfpu'
 license_text = license_text.replace('\n', '\\n').replace('"', '\\"')
 
 # Generate header
-is_git_version = run_command('git', 'rev-parse', '--is-inside-work-tree', check: false)
+is_git_version = run_command('sh', '-c', 'git', 'rev-parse', '--is-inside-work-tree', check: false)
 conf_data = configuration_data()
 conf_data.set('cc', c_compiler.get_id() + ' ' + c_compiler.version())
 conf_data.set('cxx', cpp_compiler.get_id() + ' ' + cpp_compiler.version())


### PR DESCRIPTION
Python's `subprocess.run` throws a `FileNotFound` exception if the executed command was not found. Similarly, meson's run_command will error if the command was not found (even when run with `check=False`.

This commit works around these issue by (a) handling the `FileNotFound` exception and (b) invoking Git via `sh(1)` so that a non-zero exit status is returned if Git isn't installed (which is then handled by `check=False`).

This was discovered while updating [Guix's](https://guix.gnu.org) bitwuzla package.

Previously: #114