### PR TITLE
Fix use-after-destruction MSan error in AigManager

### DIFF
--- a/src/lib/bitblast/aig/aig_manager.cpp
+++ b/src/lib/bitblast/aig/aig_manager.cpp
@@ -132,7 +132,10 @@ AigManager::AigManager()
   assert(d_false.get_id() == -AigNode::s_true_id);
 }
 
-AigManager::~AigManager() {}
+AigManager::~AigManager() {
+  d_true = AigNode();
+  d_false = AigNode();
+}
 
 const AigManager::Statistics&
 AigManager::statistics() const


### PR DESCRIPTION
In theory (and more relevantly, under MSan with `-fsanitize-memory-use-after-dtor`), `AigManager`'s memory is poisoned immediately after its destructor body completes. The subsequent automatic destruction of its `AigNode` members (`d_true` and `d_false`) triggers reference-decrement cleanup that calls back into the parent manager's `garbage_collect()`, resulting in a use-after-destruction error on reading `d_gc_mode`. 

Resetting these members to null inside the destructor body executes this cleanup while the parent's memory is still unpoisoned and valid. Since null nodes don't trigger garbage collection on destruction, this fixes the MSan errors.