### PR TITLE
rewrite: Add BV_ADD_SREM rule to reconstruct bvsrem from sdiv-eliminated form

### DIFF
--- a/src/rewrite/rewriter.cpp
+++ b/src/rewrite/rewriter.cpp
@@ -1206,6 +1206,7 @@ Rewriter::rewrite_bv_add(const Node& node)
     BZLA_APPLY_RW_RULE(BV_ADD_NOT);
     BZLA_APPLY_RW_RULE(BV_ADD_NEG);
     BZLA_APPLY_RW_RULE(BV_ADD_UREM);
+    BZLA_APPLY_RW_RULE(BV_ADD_SREM);
   }
   if (d_level >= 2)
   {
@@ -2120,6 +2121,7 @@ operator<<(std::ostream& out, RewriteRuleKind kind)
     CASE(BV_ADD_NOT);
     CASE(BV_ADD_NEG);
     CASE(BV_ADD_UREM);
+    CASE(BV_ADD_SREM);
     CASE(BV_ADD_ITE1);
     CASE(BV_ADD_ITE2);
     CASE(BV_ADD_SHL);

--- a/src/rewrite/rewriter.h
+++ b/src/rewrite/rewriter.h
@@ -470,6 +470,7 @@ enum class RewriteRuleKind
   BV_ADD_NOT,
   BV_ADD_NEG,
   BV_ADD_UREM,
+  BV_ADD_SREM,
   // Level 2+
   BV_ADD_ITE1,
   BV_ADD_ITE2,

--- a/src/rewrite/rewrites_bv.cpp
+++ b/src/rewrite/rewrites_bv.cpp
@@ -317,6 +317,92 @@ RewriteRule<RewriteRuleKind::BV_ADD_UREM>::_apply(Rewriter& rewriter,
 }
 
 /**
+ * We have for a s/ b that a = n * b + r (a - n * b = r), and thus for
+ * a - ((a s/ b) * b) = a s% b with (a s/ b) = n.
+ *
+ * Since bvsdiv and bvsrem are eliminated during rewriting (BV_SDIV_ELIM,
+ * BV_SREM_ELIM), this matches the eliminated form of
+ *   (bvadd a (bvmul (bvneg b) (bvsdiv a b)))
+ * for a value b (with msb(b) = 0, else the conditions of the two ites below
+ * differ and we do not match):
+ *
+ * match:  (bvadd a (bvmul nb (ite c (bvneg (bvudiv x b)) (bvudiv x b))))
+ *         with nb, b values such that nb = -b
+ *         and x = (ite c (bvneg a) a)
+ *         (or with the branches of both ites swapped)
+ * result: (ite c (bvneg (bvurem x b)) (bvurem x b))
+ *         (branches swapped accordingly), the eliminated form of (bvsrem a b)
+ *
+ * This is correct for any condition c: if the negated branches are not
+ * taken it is the unsigned identity x - b * (x u/ b) = x u% b with x = a,
+ * else it is the same identity for x = -a, negated.
+ */
+namespace {
+Node
+_rw_bv_add_srem(Rewriter& rewriter, const Node& node, size_t idx)
+{
+  size_t idx0   = idx;
+  size_t idx1   = 1 - idx;
+  const Node& a = node[idx1];
+  if (node[idx0].kind() != Kind::BV_MUL)
+  {
+    return node;
+  }
+  const Node& mul = node[idx0];
+  for (size_t i = 0; i < 2; ++i)
+  {
+    const Node& nb  = mul[i];
+    const Node& ite = mul[1 - i];
+    if (!nb.is_value() || ite.kind() != Kind::ITE)
+    {
+      continue;
+    }
+    const Node& cond = ite[0];
+    for (size_t j = 1; j <= 2; ++j)
+    {
+      // branch j is the negation of branch 3 - j, which is the udiv
+      Node neg_udiv;
+      if (!rewriter.is_bv_neg(ite[j], neg_udiv) || neg_udiv != ite[3 - j]
+          || neg_udiv.kind() != Kind::BV_UDIV)
+      {
+        continue;
+      }
+      const Node& x = neg_udiv[0];
+      const Node& b = neg_udiv[1];
+      if (!b.is_value() || nb.value<BitVector>() != b.value<BitVector>().bvneg())
+      {
+        continue;
+      }
+      // x = (ite c (bvneg a) a), negated on the same branch as the udiv
+      Node neg_a;
+      if (x.kind() == Kind::ITE && x[0] == cond && x[3 - j] == a
+          && rewriter.is_bv_neg(x[j], neg_a) && neg_a == a)
+      {
+        Node urem     = rewriter.mk_node(Kind::BV_UREM, {x, b});
+        Node neg_urem = rewriter.mk_node(Kind::BV_NEG, {urem});
+        return j == 1 ? rewriter.mk_node(Kind::ITE, {cond, neg_urem, urem})
+                      : rewriter.mk_node(Kind::ITE, {cond, urem, neg_urem});
+      }
+    }
+  }
+  return node;
+}
+}  // namespace
+
+template <>
+Node
+RewriteRule<RewriteRuleKind::BV_ADD_SREM>::_apply(Rewriter& rewriter,
+                                                  const Node& node)
+{
+  Node res = _rw_bv_add_srem(rewriter, node, 0);
+  if (res == node)
+  {
+    res = _rw_bv_add_srem(rewriter, node, 1);
+  }
+  return res;
+}
+
+/**
  * match:  (bvadd (ite c a b) (ite c a d))
  * result: (ite c (bvadd a a) (bvadd b d))
  *

--- a/src/rewrite/rewrites_bv.h
+++ b/src/rewrite/rewrites_bv.h
@@ -38,6 +38,10 @@ Node RewriteRule<RewriteRuleKind::BV_ADD_NOT>::_apply(Rewriter& rewriter,
 template <>
 Node RewriteRule<RewriteRuleKind::BV_ADD_UREM>::_apply(Rewriter& rewriter,
                                                        const Node& node);
+// srem_add
+template <>
+Node RewriteRule<RewriteRuleKind::BV_ADD_SREM>::_apply(Rewriter& rewriter,
+                                                       const Node& node);
 // neg_add
 template <>
 Node RewriteRule<RewriteRuleKind::BV_ADD_NEG>::_apply(Rewriter& rewriter,

--- a/test/unit/rewrite/test_rewriter_bv.cpp
+++ b/test/unit/rewrite/test_rewriter_bv.cpp
@@ -321,6 +321,70 @@ TEST_F(TestRewriterBv, bv_add_urem)
                d_nm.mk_node(Kind::BV_UDIV, {d_bv4_a, d_bv4_b}), d_bv4_b})}));
 }
 
+TEST_F(TestRewriterBv, bv_add_srem)
+{
+  constexpr RewriteRuleKind kind = RewriteRuleKind::BV_ADD_SREM;
+  // the eliminated form of (bvadd a (bvmul (bvneg b) (bvsdiv a b))) for a
+  // value b
+  Node a     = d_bv4_a;
+  Node b     = d_nm.mk_value(BitVector::from_ui(4, 5));
+  Node nb    = d_nm.mk_value(BitVector::from_ui(4, 5).bvneg());
+  Node neg_a = d_nm.mk_node(Kind::BV_NEG, {a});
+  Node x     = d_nm.mk_node(Kind::ITE, {d_c, neg_a, a});
+  Node udiv  = d_nm.mk_node(Kind::BV_UDIV, {x, b});
+  Node sdiv  = d_nm.mk_node(
+      Kind::ITE, {d_c, d_nm.mk_node(Kind::BV_NEG, {udiv}), udiv});
+  //// applies
+  test_rule<kind>(d_nm.mk_node(
+      Kind::BV_ADD, {a, d_nm.mk_node(Kind::BV_MUL, {nb, sdiv})}));
+  test_rule<kind>(d_nm.mk_node(
+      Kind::BV_ADD, {a, d_nm.mk_node(Kind::BV_MUL, {sdiv, nb})}));
+  test_rule<kind>(d_nm.mk_node(
+      Kind::BV_ADD, {d_nm.mk_node(Kind::BV_MUL, {nb, sdiv}), a}));
+  // swapped ite branches
+  Node xs    = d_nm.mk_node(Kind::ITE, {d_c, a, neg_a});
+  Node udivs = d_nm.mk_node(Kind::BV_UDIV, {xs, b});
+  Node sdivs = d_nm.mk_node(
+      Kind::ITE, {d_c, udivs, d_nm.mk_node(Kind::BV_NEG, {udivs})});
+  test_rule<kind>(d_nm.mk_node(
+      Kind::BV_ADD, {a, d_nm.mk_node(Kind::BV_MUL, {nb, sdivs})}));
+  // negations in eliminated form
+  Node neg_a_e =
+      RewriteRule<RewriteRuleKind::BV_NEG_ELIM>::apply(d_rewriter, neg_a)
+          .first;
+  Node x_e    = d_nm.mk_node(Kind::ITE, {d_c, neg_a_e, a});
+  Node udiv_e = d_nm.mk_node(Kind::BV_UDIV, {x_e, b});
+  Node sdiv_e = d_nm.mk_node(
+      Kind::ITE,
+      {d_c,
+       RewriteRule<RewriteRuleKind::BV_NEG_ELIM>::apply(
+           d_rewriter, d_nm.mk_node(Kind::BV_NEG, {udiv_e}))
+           .first,
+       udiv_e});
+  test_rule<kind>(d_nm.mk_node(
+      Kind::BV_ADD, {a, d_nm.mk_node(Kind::BV_MUL, {nb, sdiv_e})}));
+  //// does not apply
+  // multiplier is not the negation of the divisor
+  test_rule_does_not_apply<kind>(d_nm.mk_node(
+      Kind::BV_ADD,
+      {a,
+       d_nm.mk_node(Kind::BV_MUL,
+                    {d_nm.mk_value(BitVector::from_ui(4, 6).bvneg()), sdiv})}));
+  // conditions of the two ites differ
+  Node sdiv_d = d_nm.mk_node(
+      Kind::ITE, {d_d, d_nm.mk_node(Kind::BV_NEG, {udiv}), udiv});
+  test_rule_does_not_apply<kind>(d_nm.mk_node(
+      Kind::BV_ADD, {a, d_nm.mk_node(Kind::BV_MUL, {nb, sdiv_d})}));
+  // ite branches of the two ites do not align
+  Node sdiv_mixed = d_nm.mk_node(
+      Kind::ITE, {d_c, d_nm.mk_node(Kind::BV_NEG, {udivs}), udivs});
+  test_rule_does_not_apply<kind>(d_nm.mk_node(
+      Kind::BV_ADD, {a, d_nm.mk_node(Kind::BV_MUL, {nb, sdiv_mixed})}));
+  // dividend does not match the other add operand
+  test_rule_does_not_apply<kind>(d_nm.mk_node(
+      Kind::BV_ADD, {d_bv4_b, d_nm.mk_node(Kind::BV_MUL, {nb, sdiv})}));
+}
+
 // reversed by NORM_BV_NOT_OR_SHL
 // TEST_F(TestRewriterBv, bv_add_shl)
 //{


### PR DESCRIPTION
Translation-validation queries (e.g. from Alive2) frequently encode a
signed remainder as the three-instruction sequence a - (a sdiv b) * b
instead of a bvsrem. Because bvsdiv/bvsrem are eliminated into ite/bvudiv
forms during rewriting, and rewriting is bottom-up, the resulting bvadd
never gets recognized as a remainder and the solver bit-blasts two
independent signed divisions. This can turn a query that is trivial in
bvsrem form into a 90s+ timeout.

Add BV_ADD_SREM, the signed analogue of the existing BV_ADD_UREM rule. It
matches the post-elimination shape

  (bvadd a (bvmul nb (ite c (bvneg (bvudiv x b)) (bvudiv x b))))

with values nb = -b and x = (ite c (bvneg a) a), and rewrites it to the
eliminated form of (bvsrem a b). The rewrite is sound for any condition c,
so it does not need to prove that c is the sign test of a.

Registered at rewrite level 1 next to BV_ADD_UREM. Adds a bv_add_srem unit
test covering the matching shapes and near-miss non-applications.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
