### PR TITLE
sat: Add missing <cstddef> include (GCC 12 build fix)

### DIFF
--- a/src/sat/distinct_decision_heuristic.h
+++ b/src/sat/distinct_decision_heuristic.h
@@ -11,6 +11,7 @@
 #ifndef BZLA_SAT_DISTINCT_DECISION_HEURISTIC_H_INCLUDED
 #define BZLA_SAT_DISTINCT_DECISION_HEURISTIC_H_INCLUDED
 
+#include <cstddef>
 #include <unordered_map>
 #include <vector>
 

--- a/src/sat/eq_decision_heuristic.h
+++ b/src/sat/eq_decision_heuristic.h
@@ -11,6 +11,7 @@
 #ifndef BZLA_SAT_EQ_DECISION_HEURISTIC_H_INCLUDED
 #define BZLA_SAT_EQ_DECISION_HEURISTIC_H_INCLUDED
 
+#include <cstddef>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
The decision-heuristic headers added in 86ee1027 (`sat: Add equality and distinct decision heuristics.`) fail to compile with **GCC 12** (e.g. Ubuntu 22.04, GCC 12.3.0):

```
../src/sat/eq_decision_heuristic.h:34:31: error: 'size_t' was not declared in this scope; did you mean 'std::size_t'?
../src/sat/distinct_decision_heuristic.h:34:31: error: 'size_t' was not declared in this scope; did you mean 'std::size_t'?
```

Both headers use an unqualified `size_t` (`std::unordered_map<int32_t, size_t> d_idxmap;`) but only include `<unordered_map>`, `<vector>` and `sat/sat_propagator.h`. On GCC 13+/clang the type is made visible transitively through those headers, but GCC 12's libstdc++ does not, so it errors. Adding `#include <cstddef>` explicitly (as done elsewhere in the tree, e.g. `lib/bitblast/bitblaster.h`) fixes it and lets the full build complete on GCC 12.

The CI matrix currently covers `ubuntu-latest` (GCC 13/14), `macos-latest`, `ubuntu-24.04-arm` and clang, so GCC 12 isn't exercised — hence this wasn't caught.

Same class of toolchain-portability fix as #174.