### PR TITLE
Fix use-after-free in FunSolver::check() (#216)

### DIFF
--- a/src/solver/fun/fun_solver.cpp
+++ b/src/solver/fun/fun_solver.cpp
@@ -57,7 +57,10 @@ FunSolver::check()
   // Do not cache size here since d_applies may grow while iterating.
   for (size_t i = 0; i < d_applies.size(); ++i)
   {
-    const Node& apply = d_applies[i];
+    // Copy, do not take a reference here: constructing Apply below queries
+    // model values, which re-enters register_term() and may push onto (and
+    // thus reallocate) d_applies, invalidating references into it.
+    Node apply      = d_applies[i];
     const Node& fun = apply[0];
     auto& fun_model = d_fun_models[fun];
 
@@ -277,15 +280,18 @@ FunSolver::Apply::Apply(const Node& apply,
 {
   // Compute hash value of function applications based on the current function
   // argument model values.
-  for (size_t i = 1, size = apply.num_children(); i < size; ++i)
+  // Note: Use d_apply, not the `apply` parameter, throughout. state.value()
+  // may re-enter FunSolver::register_term() and invalidate whatever storage
+  // `apply` refers to, whereas d_apply is our own copy.
+  for (size_t i = 1, size = d_apply.num_children(); i < size; ++i)
   {
-    d_values.emplace_back(state.value(apply[i]));
+    d_values.emplace_back(state.value(d_apply[i]));
     d_hash += std::hash<Node>{}(d_values.back());
   }
   if (cache_apply_value)
   {
     // Cache value of function application
-    d_value = state.value(apply);
+    d_value = state.value(d_apply);
   }
 }
 

--- a/src/solver/solver_engine.cpp
+++ b/src/solver/solver_engine.cpp
@@ -341,7 +341,17 @@ SolverEngine::check_distinct_n()
   NodeManager& nm = d_env.nm();
   for (size_t i = 0, size = d_distinct_n.size(); i < size; ++i)
   {
-    const Node& dc = d_distinct_n[i];
+    // Copy rather than reference d_distinct_n[i]: the value() queries below
+    // re-enter process_term(), which pushes onto d_distinct_n when it sees an
+    // unregistered DISTINCT_N, and a reallocation would leave a reference here
+    // dangling (cf. the same defect in FunSolver::check(), issue #216).
+    //
+    // No input is currently known to reach that, and by inspection none can:
+    // process_term() does not descend into DISTINCT_N children, DISTINCT_N is
+    // only ever built by ArraySolver's const-array-diff lemma, and lemmas are
+    // registered in process_lemmas() rather than here. Those are implicit
+    // invariants though, so do not rely on them to stay true.
+    Node dc = d_distinct_n[i];
 
     Node dc_val = d_solver_state.value(dc);
 

--- a/test/regress/check/regr_issue216.smt2
+++ b/test/regress/check/regr_issue216.smt2
@@ -1,0 +1,8 @@
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 11 53))
+(define-fun m () (_ FloatingPoint 11 53) (fp.min x (fp.neg x)))
+(assert (fp.lt ((_ to_fp_unsigned 11 53) RNE
+                 ((_ fp.to_ubv 1) RNE (fp.mul RNE m m)))
+               x))
+(set-info :status sat)
+(check-sat)

--- a/test/regress/check/regr_issue216b.smt2
+++ b/test/regress/check/regr_issue216b.smt2
@@ -1,0 +1,9 @@
+; Regression test for issue #216: use-after-free in FunSolver::check().
+; Constructing Apply re-enters register_term(), which reallocates d_applies
+; and invalidates the Node reference held by check() / the Apply constructor.
+;
+; Ground QF_BVFP witness reaching the same defect via check-sat-assuming.
+; Segfaulted deterministically (exit 139, no output) before the fix.
+(set-logic QF_BVFP)
+(set-info :status sat)
+(check-sat-assuming ((fp.isNormal ((_ to_fp 15 113) RTP ((_ fp.to_ubv 125) RTP (fp.div RTP (fp (_ bv0 1) (_ bv0 15) (_ bv0 112)) (fp.max (fp (_ bv0 1) (_ bv0 15) (_ bv0 112)) (fp (_ bv1 1) (_ bv0 15) (_ bv0 112)))))))))

--- a/test/regress/meson.build
+++ b/test/regress/meson.build
@@ -21,6 +21,8 @@ tests_smt2 = [
   ['check/regr_cm7.smt2'],
   ['check/regr_cm8.smt2'],
   ['check/regr_cm9.smt2'],
+  ['check/regr_issue216.smt2'],
+  ['check/regr_issue216b.smt2'],
   ['check/regr_uc1.smt2'],
   ## get-model
   ['get-model/regr-5smod3.btor.smt2', ['--print-model']],


### PR DESCRIPTION
Fixes #216.

## Root cause

`check()` holds `const Node& apply = d_applies[i]`. Constructing `Apply` calls `SolverState::value()`, which re-enters `process_term() → register_term() → d_applies.push_back()`, reallocating the vector and leaving `apply` dangling. The loop anticipated the growth (`size()` is deliberately not cached), but not the buffer moving.

`Apply::Apply` has the same exposure: it copies into `d_apply`, but its body keeps using the `apply` **parameter**, so `state.value(apply)` passes freed memory to `Node::kind()` — the top frame of the issue's Valgrind trace.

## Second commit — speculative, drop if unwanted

`check_distinct_n()` has the same reference-across-`value()` shape, safe today only via undocumented invariants (`process_term()` skips `DISTINCT_N` children; `DISTINCT_N` has one construction site; lemmas register elsewhere). I could not trigger it — instrumenting for reallocation showed no growth across the regress corpus, seven option configurations, or targeted stress inputs. This just takes a copy and records the invariants so a future change cannot silently reintroduce #216 there.

## Testing

Two tests added, both confirmed to fail before and pass after:

- `regr_issue216.smt2` — the issue's QF_FP input (`bad_alloc` ~28/30 runs).
- `regr_issue216b.smt2` — a ground QF_BVFP witness via `check-sat-assuming` (SIGSEGV 30/30), murxla-found and ddSMT-reduced.

Valgrind: 0 errors, from 14 invalid reads across 13 contexts. Full regress suite 4030/4030. `clang-format` clean.
